### PR TITLE
When rbenv is already available, no need to add $RBENV_ROOT/bin

### DIFF
--- a/rbenv.fish
+++ b/rbenv.fish
@@ -2,7 +2,7 @@
 #   rbenv plugin for oh my fish
 
 function init --on-event init_rbenv
-  if set -q RBENV_ROOT; and not contains "$RBENV_ROOT/bin" $PATH
+  if not available rbenv; and set -q RBENV_ROOT; and not contains "$RBENV_ROOT/bin" $PATH
     set PATH $RBENV_ROOT/bin $PATH
   end
 


### PR DESCRIPTION
Followin the [issue #13](https://github.com/oh-my-fish/plugin-rbenv/issues/13), it could be better to check wether the rbenv command is already available before adding $RBENV_ROOT/bin to the path (especially when there is no $RBENV_ROOT/bin ^^).
