### PR TITLE
Replace `available` usage with `type -q`

### DIFF
--- a/rbenv.fish
+++ b/rbenv.fish
@@ -2,11 +2,11 @@
 #   rbenv plugin for oh my fish
 
 function init --on-event init_rbenv
-  if not available rbenv; and set -q RBENV_ROOT; and not contains "$RBENV_ROOT/bin" $PATH
+  if not type -q rbenv; and set -q RBENV_ROOT; and not contains "$RBENV_ROOT/bin" $PATH
     set PATH $RBENV_ROOT/bin $PATH
   end
 
-  if not available rbenv
+  if not type -q rbenv
     echo "Please install 'rbenv' first, or set \$RBENV_ROOT!"; return 1
   end
 

--- a/test/rbenv.fish
+++ b/test/rbenv.fish
@@ -1,1 +1,1 @@
-test available rbenv
+test type -q rbenv


### PR DESCRIPTION
`available` isn't super fishy, let's use `type -q` instead. it's quiet, it avoids redirection, and @derekstavis likes it better :P
